### PR TITLE
Fix custom filter name issue

### DIFF
--- a/Signals And Transforms/Views/FilterView.xaml.cs
+++ b/Signals And Transforms/Views/FilterView.xaml.cs
@@ -165,7 +165,7 @@ namespace SignalsAndTransforms.Views
                         WorkBookManager manager = WorkBookManager.Manager();
 
                         SignalsAndTransforms.Models.CustomFilter customFilter = new SignalsAndTransforms.Models.CustomFilter(magPhaseList);
-                        customFilter.Name = "Test";
+                        customFilter.Name = System.IO.Path.GetFileNameWithoutExtension(openFileDialog.FileName);
                         customFilter.IsActive = true;
 
                         FilterViewModel context = DataContext as FilterViewModel;


### PR DESCRIPTION
File name (without path or extension) now used as the filter name on custom filter import